### PR TITLE
R utilities

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,6 @@ Imports: Rcpp (>= 0.12.4), xml2
 LinkingTo: Rcpp, RcppArmadillo, BH
 VignetteBuilder: knitr
 Suggests:
-    rlang,
     knitr,
     testthat (>= 2.1.0)
 URL: http://www.mlpack.org/

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -49,8 +49,40 @@ CLI_SetParamBool <- function(paramName, paramValue) {
     invisible(.Call(`_RcppMLPACK_CLI_SetParamBool`, paramName, paramValue))
 }
 
-CLI_SetParamMat <- function(paramName, paramValue, copyAllInputs) {
-    invisible(.Call(`_RcppMLPACK_CLI_SetParamMat`, paramName, paramValue, copyAllInputs))
+CLI_SetParamVectorStr <- function(paramName, str) {
+    invisible(.Call(`_RcppMLPACK_CLI_SetParamVectorStr`, paramName, str))
+}
+
+CLI_SetParamVectorInt <- function(paramName, ints) {
+    invisible(.Call(`_RcppMLPACK_CLI_SetParamVectorInt`, paramName, ints))
+}
+
+CLI_SetParamMat <- function(paramName, paramValue) {
+    invisible(.Call(`_RcppMLPACK_CLI_SetParamMat`, paramName, paramValue))
+}
+
+CLI_SetParamUMat <- function(paramName, paramValue) {
+    invisible(.Call(`_RcppMLPACK_CLI_SetParamUMat`, paramName, paramValue))
+}
+
+CLI_SetParamRow <- function(paramName, paramValue) {
+    invisible(.Call(`_RcppMLPACK_CLI_SetParamRow`, paramName, paramValue))
+}
+
+CLI_SetParamURow <- function(paramName, paramValue) {
+    invisible(.Call(`_RcppMLPACK_CLI_SetParamURow`, paramName, paramValue))
+}
+
+CLI_SetParamCol <- function(paramName, paramValue) {
+    invisible(.Call(`_RcppMLPACK_CLI_SetParamCol`, paramName, paramValue))
+}
+
+CLI_SetParamUCol <- function(paramName, paramValue) {
+    invisible(.Call(`_RcppMLPACK_CLI_SetParamUCol`, paramName, paramValue))
+}
+
+CLI_SetParamMatWithInfo <- function(paramName, dimensions, paramValue) {
+    invisible(.Call(`_RcppMLPACK_CLI_SetParamMatWithInfo`, paramName, dimensions, paramValue))
 }
 
 CLI_GetParamInt <- function(paramName) {
@@ -69,8 +101,40 @@ CLI_GetParamBool <- function(paramName) {
     .Call(`_RcppMLPACK_CLI_GetParamBool`, paramName)
 }
 
+CLI_GetParamVectorStr <- function(paramName) {
+    .Call(`_RcppMLPACK_CLI_GetParamVectorStr`, paramName)
+}
+
+CLI_GetParamVectorInt <- function(paramName) {
+    .Call(`_RcppMLPACK_CLI_GetParamVectorInt`, paramName)
+}
+
 CLI_GetParamMat <- function(paramName) {
     .Call(`_RcppMLPACK_CLI_GetParamMat`, paramName)
+}
+
+CLI_GetParamUMat <- function(paramName) {
+    .Call(`_RcppMLPACK_CLI_GetParamUMat`, paramName)
+}
+
+CLI_GetParamRow <- function(paramName) {
+    .Call(`_RcppMLPACK_CLI_GetParamRow`, paramName)
+}
+
+CLI_GetParamURow <- function(paramName) {
+    .Call(`_RcppMLPACK_CLI_GetParamURow`, paramName)
+}
+
+CLI_GetParamCol <- function(paramName) {
+    .Call(`_RcppMLPACK_CLI_GetParamCol`, paramName)
+}
+
+CLI_GetParamUCol <- function(paramName) {
+    .Call(`_RcppMLPACK_CLI_GetParamUCol`, paramName)
+}
+
+CLI_GetParamMatWithInfo <- function(paramName) {
+    .Call(`_RcppMLPACK_CLI_GetParamMatWithInfo`, paramName)
 }
 
 CLI_EnableVerbose <- function() {

--- a/R/lars.R
+++ b/R/lars.R
@@ -58,10 +58,6 @@
 #' @param test Matrix containing points to regress on (test points).
 #' @param use_cholesky Use Cholesky decomposition during computation
 #'  rather than explicitly computing the full Gram matrix.  Default value `FALSE`.
-#' @param copy_all_inputs If specified, all input parameters will be
-#' deep copied before the method is run.  This is useful for debugging
-#' problems where the input parameters are being modified by the algorithm,
-#' but can slow down the code.
 #' @param verbose Display informational messages and the full list of
 #'  parameters and timers at the end of execution.  Default value `FALSE`.
 #'
@@ -80,12 +76,11 @@ lars <- function(input = matrix(NA),
                  responses = matrix(NA),
                  test = matrix(NA),
                  use_cholesky = FALSE,
-                 copy_all_inputs = FALSE,
                  verbose = FALSE) {
   CLI_RestoreSettings("LARS")
 
   if (!identical(input, matrix(NA))) {
-    CLI_SetParamMat("input", input, copy_all_inputs)
+    CLI_SetParamMat("input", to_matrix(input))
   }
 
   if (!identical(input_model, NULL)) {
@@ -101,18 +96,18 @@ lars <- function(input = matrix(NA),
   }
 
   if (!identical(responses, matrix(NA))) {
-    CLI_SetParamMat("responses", responses, copy_all_inputs)
+    CLI_SetParamMat("responses", to_matrix(responses))
   }
 
   if (!identical(test, matrix(NA))) {
-    CLI_SetParamMat("test", test, copy_all_inputs)
+    CLI_SetParamMat("test", to_matrix(test))
   }
 
   if (use_cholesky != FALSE) {
     CLI_SetParamBool("use_cholesky", use_cholesky)
   }
 
-  if (verbose != FALSE || verbose == TRUE) {
+  if (verbose) {
     CLI_EnableVerbose()
   } else {
     CLI_DisableVerbose()

--- a/R/matrix_utils.R
+++ b/R/matrix_utils.R
@@ -1,0 +1,50 @@
+# matrix_utils.R: utilities for matrix conversion
+#
+# This file defines the to_matrix() function, which can be used to convert
+# data.frame or other types of matrix-like objects to matrix for use in
+# mlpack bindings(CLI_SetParamMat/UMat).
+#
+# This file also defines the to_matirx_with_info() function, which can be used
+# to construct dataset information vector from the given dataset for use in 
+# mlpack bindings(CLI_SetParamMatWithInfo).
+#
+# 
+# mlpack is free software; you may redistribute it and/or modify it under the
+# terms of the 3-clause BSD license.  You should have received a copy of the
+# 3-clause BSD license along with mlpack.  If not, see
+# http://www.opensource.org/licenses/BSD-3-Clause for more information.
+
+# Given some matrix-like x (which should be either a matrix or
+# data.frame), convert it into a matrix.
+to_matrix <- function(x) {
+  if (!is.matrix(x) && !is.data.frame(x)) {
+    stop("given argument is not matrix-like")
+  }
+  if (is.matrix(x)) {
+    return(x)
+  }
+  else if (is.data.frame(x)) {
+    y <- data.matrix(x)
+    return(y)
+  }
+}
+
+# Determine column classes
+mark_categorical_variable = function(x) {
+  d <- sapply(x, class) %in% c("factor", "character", "logical")
+  d
+}
+
+# Given some matrix-like x (which should be either a matrix or
+# data.frame), convert it into a matrix.
+to_matrix_with_info <- function(x) {
+  
+  # Handle transformation
+  transformed_x <- to_matrix(x)
+
+  # Figure out categoricals
+  info <- mark_categorical_variable(x)
+  
+  # Return needed data. 
+  return(list("info" = info, "data" = transformed_x))
+}

--- a/R/pca.R
+++ b/R/pca.R
@@ -37,10 +37,6 @@
 #' @param var_to_retain Amount of variance to retain; should be
 #' between 0 and 1.  If 1, all variance is retained.  Overrides -d.  Default
 #' value `0`.
-#' @param copy_all_inputs If specified, all input parameters will be
-#' deep copied before the method is run.  This is useful for debugging
-#' problems where the input parameters are being modified by the algorithm,
-#' but can slow down the code.
 #' @param verbose Display informational messages and the full list of
 #' parameters and timers at the end of execution.  Default value `FALSE`.
 #'
@@ -54,12 +50,11 @@ pca <- function(input,
                 new_dimensionality = 0,
                 scale = FALSE,
                 var_to_retain = 0,
-                copy_all_inputs = FALSE,
                 verbose = FALSE) {
   CLI_RestoreSettings("Principal Components Analysis")
 
   # Process each input argument before calling mlpackMain().
-  CLI_SetParamMat("input", input, copy_all_inputs)
+  CLI_SetParamMat("input", to_matrix(input))
 
   if (decomposition_method != "exact") {
     CLI_SetParamString("decomposition_method", decomposition_method)
@@ -77,7 +72,7 @@ pca <- function(input,
     CLI_SetParamDouble("var_to_retain", var_to_retain)
   }
 
-  if (verbose != FALSE || verbose == TRUE) {
+  if (verbose) {
     CLI_EnableVerbose()
   } else {
     CLI_DisableVerbose()

--- a/R/r_util.R
+++ b/R/r_util.R
@@ -1,6 +1,0 @@
-CLIGetParamMat <- function(paramName, paramValue) {
-  mat <- CLI_GetParamMat(as.character(paramName))
-  nrows <- CLI_GetParamMatRows(as.character(paramName))
-  ncols <- CLI_GetParamMatCols(as.character(paramName))
-  return(matrix(mat, nrows, ncols))
-}

--- a/R/test_r_binding.R
+++ b/R/test_r_binding.R
@@ -4,39 +4,59 @@
 #' @param double_in Input double, must be 4.0.
 #' @param int_in Input int, must be 12.
 #' @param string_in Input string, must be 'hello'.
-#' @param matrix_in Input matrix.
 #' @param build_model If true, a model will be returned.
+#' @param col_in Input column.
 #' @param flag1 Input flag, must be specified.
 #' @param flag2 Input flag, must not be specified.
+#' @param matrix_and_info_in Input matrix and info.
+#' @param matrix_in Input matrix.
 #' @param model_in Input model.
-#' @param copy_all_inputs If specified, all input parameters will be
-#' deep copied before the method is run.  This is useful for debugging
-#' problems where the input parameters are being modified by the algorithm,
-#' but can slow down the code.
+#' @param row_in Input row.
+#' @param str_vector_in Input vector of strings.
+#' @param ucol_in Input unsigned column.
+#' @param umatrix_in Input unsigned matrix.
+#' @param urow_in Input unsigned row.
+#' @param vector_in Input unsigned vector.
 #' @param verbose Display informational messages and the full list of
 #' parameters and timers at the end of execution.  Default value `FALSE`.
 #'
 #' @return A list with several components:
+#' \item{col_out}{ Output column. 2x input column}
 #' \item{double_out}{ Output double, will be 5.0.}
 #' \item{int_out}{ Output int, will be 13.}
-#' \item{string_out}{ Output string, will be 'hello2'.}
+#' \item{matrix_and_info_out}{ Output matrix and info; all
+#'       numeric elements multiplied by 3. }
 #' \item{matrix_out}{ Output matrix.}
-#' \item{model_out}{ Output model, with twice the bandwidth.}
 #' \item{model_bw_out}{ The bandwidth of the model.}
+#' \item{model_out}{ Output model, with twice the bandwidth.}
+#' \item{row_out}{ Output row.  2x input row.}
+#' \item{str_vector_out}{ Output string vector.}
+#' \item{string_out}{ Output string, will be 'hello2'.}
+#' \item{ucol_out}{ Output unsigned column. 2x input column.}
+#' \item{umatrix_out}{ Output unsigned matrix.}
+#' \item{urow_out}{ Output unsigned row.  2x input row.}
+#' \item{vector_out}{ Output vector.}
 #' @examples
 #' ## test_r_binding:
-#' x <- matrix(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15), nrow = 5)
+#' x <- matrix(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15), nrow = 3)
 #' out1 <- test_r_binding(4.0, 12, "hello", flag1 = TRUE, build_model = TRUE)
-#' out2 <- test_r_binding(4.0, 12, "hello", x, TRUE, TRUE, model_in = out1$model_out)
+#' out2 <- test_r_binding(4.0, 12, "hello", matrix_in=x, model_in = out1$model_out)
 test_r_binding <- function(double_in,
                            int_in,
                            string_in,
-                           matrix_in = matrix(NA),
                            build_model = FALSE,
+                           col_in = matrix(NA),
                            flag1 = FALSE,
                            flag2 = FALSE,
+                           matrix_and_info_in = data.frame(NA),
+                           matrix_in = matrix(NA),
                            model_in = NULL,
-                           copy_all_inputs = FALSE,
+                           row_in = matrix(NA),
+                           str_vector_in = NA,
+                           ucol_in = matrix(NA),
+                           umatrix_in = matrix(NA),
+                           urow_in = matrix(NA),
+                           vector_in = NA,
                            verbose = FALSE) {
   CLI_RestoreSettings("R binding test")
 
@@ -50,12 +70,8 @@ test_r_binding <- function(double_in,
     CLI_SetParamBool("build_model", build_model)
   }
 
-  if (!identical(model_in, NULL)) {
-    CLI_SetParamGaussianKernelPtr("model_in", model_in)
-  }
-
-  if (!identical(matrix_in, matrix(NA))) {
-    CLI_SetParamMat("matrix_in", matrix_in, copy_all_inputs)
+  if (!identical(col_in, matrix(NA))) {
+    CLI_SetParamCol("col_in", to_matrix(col_in))
   }
 
   if (flag1 != FALSE) {
@@ -66,32 +82,85 @@ test_r_binding <- function(double_in,
     CLI_SetParamBool("flag2", flag2)
   }
 
-  if (verbose != FALSE || verbose == TRUE) {
+  if (!identical(matrix_and_info_in, data.frame(NA))) {
+    mat_and_info <- to_matrix_with_info(matrix_and_info_in)
+    CLI_SetParamMatWithInfo("matrix_and_info_in", mat_and_info$info, mat_and_info$data)
+  }
+
+  if (!identical(matrix_in, matrix(NA))) {
+    CLI_SetParamMat("matrix_in", to_matrix(matrix_in))
+  }
+
+  if (!identical(model_in, NULL)) {
+    CLI_SetParamGaussianKernelPtr("model_in", model_in)
+  }
+
+  if (!identical(row_in, NA)) {
+    CLI_SetParamRow("row_in", to_matrix(row_in))
+  }
+
+  if (!identical(str_vector_in, NA)) {
+    CLI_SetParamVectorStr("str_vector_in", str_vector_in)
+  }
+
+  if (!identical(ucol_in, matrix(NA))) {
+    CLI_SetParamUCol("ucol_in", to_matrix(ucol_in))
+  }
+
+  if (!identical(umatrix_in, matrix(NA))) {
+    CLI_SetParamUMat("umatrix_in", to_matrix(umatrix_in))
+  }
+
+  if (!identical(urow_in, matrix(NA))) {
+    CLI_SetParamURow("urow_in", to_matrix(urow_in))
+  }
+
+  if (!identical(vector_in, NA)) {
+    CLI_SetParamVectorInt("vector_in", vector_in)
+  }
+
+  if (verbose) {
     CLI_EnableVerbose()
   } else {
     CLI_DisableVerbose()
   }
 
+  CLI_SetPassed("col_out")
   CLI_SetPassed("double_out")
   CLI_SetPassed("int_out")
-  CLI_SetPassed("string_out")
+  CLI_SetPassed("matrix_and_info_out")
   CLI_SetPassed("matrix_out")
-  CLI_SetPassed("model_out")
   CLI_SetPassed("model_bw_out")
+  CLI_SetPassed("model_out")
+  CLI_SetPassed("row_out")
+  CLI_SetPassed("str_vector_out")
+  CLI_SetPassed("string_out")
+  CLI_SetPassed("ucol_out")
+  CLI_SetPassed("umatrix_out")
+  CLI_SetPassed("urow_out")
+  CLI_SetPassed("vector_out")
 
   test_r_binding_mlpackMain()
 
   out <- list(
+    "col_out" = CLI_GetParamCol("col_out"),
     "double_out" = CLI_GetParamDouble("double_out"),
     "int_out" = CLI_GetParamInt("int_out"),
-    "string_out" = CLI_GetParamString("string_out"),
+    "matrix_and_info_out" = CLI_GetParamMat("matrix_and_info_out"),
     "matrix_out" = CLI_GetParamMat("matrix_out"),
+    "model_bw_out" = CLI_GetParamDouble("model_bw_out"),
     "model_out" = CLI_GetParamGaussianKernelPtr("model_out"),
-    "model_bw_out" = CLI_GetParamDouble("model_bw_out")
+    "row_out" = CLI_GetParamRow("row_out"),
+    "str_vector_out" = CLI_GetParamVectorStr("str_vector_out"),
+    "string_out" = CLI_GetParamString("string_out"),
+    "ucol_out" = CLI_GetParamUCol("ucol_out"),
+    "umatrix_out" = CLI_GetParamUMat("umatrix_out"),
+    "urow_out" = CLI_GetParamURow("urow_out"),
+    "vector_out" = CLI_GetParamVectorInt("vector_out")
   )
 
   CLI_ClearSettings()
-  
+
   return(out)
 }
 

--- a/man/lars.Rd
+++ b/man/lars.Rd
@@ -12,7 +12,6 @@ lars(
   responses = matrix(NA),
   test = matrix(NA),
   use_cholesky = FALSE,
-  copy_all_inputs = FALSE,
   verbose = FALSE
 )
 }
@@ -31,11 +30,6 @@ lars(
 
 \item{use_cholesky}{Use Cholesky decomposition during computation
 rather than explicitly computing the full Gram matrix.  Default value `FALSE`.}
-
-\item{copy_all_inputs}{If specified, all input parameters will be
-deep copied before the method is run.  This is useful for debugging
-problems where the input parameters are being modified by the algorithm,
-but can slow down the code.}
 
 \item{verbose}{Display informational messages and the full list of
 parameters and timers at the end of execution.  Default value `FALSE`.}

--- a/man/pca.Rd
+++ b/man/pca.Rd
@@ -10,7 +10,6 @@ pca(
   new_dimensionality = 0,
   scale = FALSE,
   var_to_retain = 0,
-  copy_all_inputs = FALSE,
   verbose = FALSE
 )
 }
@@ -30,11 +29,6 @@ that the variance of each feature is 1.  Default value `FALSE`.}
 \item{var_to_retain}{Amount of variance to retain; should be
 between 0 and 1.  If 1, all variance is retained.  Overrides -d.  Default
 value `0`.}
-
-\item{copy_all_inputs}{If specified, all input parameters will be
-deep copied before the method is run.  This is useful for debugging
-problems where the input parameters are being modified by the algorithm,
-but can slow down the code.}
 
 \item{verbose}{Display informational messages and the full list of
 parameters and timers at the end of execution.  Default value `FALSE`.}

--- a/man/test_r_binding.Rd
+++ b/man/test_r_binding.Rd
@@ -8,12 +8,19 @@ test_r_binding(
   double_in,
   int_in,
   string_in,
-  matrix_in = matrix(NA),
   build_model = FALSE,
+  col_in = matrix(NA),
   flag1 = FALSE,
   flag2 = FALSE,
+  matrix_and_info_in = data.frame(NA),
+  matrix_in = matrix(NA),
   model_in = NULL,
-  copy_all_inputs = FALSE,
+  row_in = matrix(NA),
+  str_vector_in = NA,
+  ucol_in = matrix(NA),
+  umatrix_in = matrix(NA),
+  urow_in = matrix(NA),
+  vector_in = NA,
   verbose = FALSE
 )
 }
@@ -24,39 +31,59 @@ test_r_binding(
 
 \item{string_in}{Input string, must be 'hello'.}
 
-\item{matrix_in}{Input matrix.}
-
 \item{build_model}{If true, a model will be returned.}
+
+\item{col_in}{Input column.}
 
 \item{flag1}{Input flag, must be specified.}
 
 \item{flag2}{Input flag, must not be specified.}
 
+\item{matrix_and_info_in}{Input matrix and info.}
+
+\item{matrix_in}{Input matrix.}
+
 \item{model_in}{Input model.}
 
-\item{copy_all_inputs}{If specified, all input parameters will be
-deep copied before the method is run.  This is useful for debugging
-problems where the input parameters are being modified by the algorithm,
-but can slow down the code.}
+\item{row_in}{Input row.}
+
+\item{str_vector_in}{Input vector of strings.}
+
+\item{ucol_in}{Input unsigned column.}
+
+\item{umatrix_in}{Input unsigned matrix.}
+
+\item{urow_in}{Input unsigned row.}
+
+\item{vector_in}{Input unsigned vector.}
 
 \item{verbose}{Display informational messages and the full list of
 parameters and timers at the end of execution.  Default value `FALSE`.}
 }
 \value{
 A list with several components:
+\item{col_out}{ Output column. 2x input column}
 \item{double_out}{ Output double, will be 5.0.}
 \item{int_out}{ Output int, will be 13.}
-\item{string_out}{ Output string, will be 'hello2'.}
+\item{matrix_and_info_out}{ Output matrix and info; all
+      numeric elements multiplied by 3. }
 \item{matrix_out}{ Output matrix.}
-\item{model_out}{ Output model, with twice the bandwidth.}
 \item{model_bw_out}{ The bandwidth of the model.}
+\item{model_out}{ Output model, with twice the bandwidth.}
+\item{row_out}{ Output row.  2x input row.}
+\item{str_vector_out}{ Output string vector.}
+\item{string_out}{ Output string, will be 'hello2'.}
+\item{ucol_out}{ Output unsigned column. 2x input column.}
+\item{umatrix_out}{ Output unsigned matrix.}
+\item{urow_out}{ Output unsigned row.  2x input row.}
+\item{vector_out}{ Output vector.}
 }
 \description{
 A simple program to test R binding functionality.
 }
 \examples{
 ## test_r_binding:
-x <- matrix(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15), nrow = 5)
+x <- matrix(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15), nrow = 3)
 out1 <- test_r_binding(4.0, 12, "hello", flag1 = TRUE, build_model = TRUE)
-out2 <- test_r_binding(4.0, 12, "hello", x, TRUE, TRUE, model_in = out1$model_out)
+out2 <- test_r_binding(4.0, 12, "hello", matrix_in=x, model_in = out1$model_out)
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -134,15 +134,103 @@ BEGIN_RCPP
     return R_NilValue;
 END_RCPP
 }
-// CLI_SetParamMat
-void CLI_SetParamMat(const std::string& paramName, arma::mat& paramValue, const bool copyAllInputs);
-RcppExport SEXP _RcppMLPACK_CLI_SetParamMat(SEXP paramNameSEXP, SEXP paramValueSEXP, SEXP copyAllInputsSEXP) {
+// CLI_SetParamVectorStr
+void CLI_SetParamVectorStr(const std::string& paramName, const std::vector<std::string>& str);
+RcppExport SEXP _RcppMLPACK_CLI_SetParamVectorStr(SEXP paramNameSEXP, SEXP strSEXP) {
 BEGIN_RCPP
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const std::string& >::type paramName(paramNameSEXP);
-    Rcpp::traits::input_parameter< arma::mat& >::type paramValue(paramValueSEXP);
-    Rcpp::traits::input_parameter< const bool >::type copyAllInputs(copyAllInputsSEXP);
-    CLI_SetParamMat(paramName, paramValue, copyAllInputs);
+    Rcpp::traits::input_parameter< const std::vector<std::string>& >::type str(strSEXP);
+    CLI_SetParamVectorStr(paramName, str);
+    return R_NilValue;
+END_RCPP
+}
+// CLI_SetParamVectorInt
+void CLI_SetParamVectorInt(const std::string& paramName, const std::vector<int>& ints);
+RcppExport SEXP _RcppMLPACK_CLI_SetParamVectorInt(SEXP paramNameSEXP, SEXP intsSEXP) {
+BEGIN_RCPP
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const std::string& >::type paramName(paramNameSEXP);
+    Rcpp::traits::input_parameter< const std::vector<int>& >::type ints(intsSEXP);
+    CLI_SetParamVectorInt(paramName, ints);
+    return R_NilValue;
+END_RCPP
+}
+// CLI_SetParamMat
+void CLI_SetParamMat(const std::string& paramName, const arma::mat& paramValue);
+RcppExport SEXP _RcppMLPACK_CLI_SetParamMat(SEXP paramNameSEXP, SEXP paramValueSEXP) {
+BEGIN_RCPP
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const std::string& >::type paramName(paramNameSEXP);
+    Rcpp::traits::input_parameter< const arma::mat& >::type paramValue(paramValueSEXP);
+    CLI_SetParamMat(paramName, paramValue);
+    return R_NilValue;
+END_RCPP
+}
+// CLI_SetParamUMat
+void CLI_SetParamUMat(const std::string& paramName, const arma::Mat<size_t>& paramValue);
+RcppExport SEXP _RcppMLPACK_CLI_SetParamUMat(SEXP paramNameSEXP, SEXP paramValueSEXP) {
+BEGIN_RCPP
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const std::string& >::type paramName(paramNameSEXP);
+    Rcpp::traits::input_parameter< const arma::Mat<size_t>& >::type paramValue(paramValueSEXP);
+    CLI_SetParamUMat(paramName, paramValue);
+    return R_NilValue;
+END_RCPP
+}
+// CLI_SetParamRow
+void CLI_SetParamRow(const std::string& paramName, const arma::rowvec& paramValue);
+RcppExport SEXP _RcppMLPACK_CLI_SetParamRow(SEXP paramNameSEXP, SEXP paramValueSEXP) {
+BEGIN_RCPP
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const std::string& >::type paramName(paramNameSEXP);
+    Rcpp::traits::input_parameter< const arma::rowvec& >::type paramValue(paramValueSEXP);
+    CLI_SetParamRow(paramName, paramValue);
+    return R_NilValue;
+END_RCPP
+}
+// CLI_SetParamURow
+void CLI_SetParamURow(const std::string& paramName, const arma::Row<size_t>& paramValue);
+RcppExport SEXP _RcppMLPACK_CLI_SetParamURow(SEXP paramNameSEXP, SEXP paramValueSEXP) {
+BEGIN_RCPP
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const std::string& >::type paramName(paramNameSEXP);
+    Rcpp::traits::input_parameter< const arma::Row<size_t>& >::type paramValue(paramValueSEXP);
+    CLI_SetParamURow(paramName, paramValue);
+    return R_NilValue;
+END_RCPP
+}
+// CLI_SetParamCol
+void CLI_SetParamCol(const std::string& paramName, const arma::vec& paramValue);
+RcppExport SEXP _RcppMLPACK_CLI_SetParamCol(SEXP paramNameSEXP, SEXP paramValueSEXP) {
+BEGIN_RCPP
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const std::string& >::type paramName(paramNameSEXP);
+    Rcpp::traits::input_parameter< const arma::vec& >::type paramValue(paramValueSEXP);
+    CLI_SetParamCol(paramName, paramValue);
+    return R_NilValue;
+END_RCPP
+}
+// CLI_SetParamUCol
+void CLI_SetParamUCol(const std::string& paramName, const arma::Col<size_t>& paramValue);
+RcppExport SEXP _RcppMLPACK_CLI_SetParamUCol(SEXP paramNameSEXP, SEXP paramValueSEXP) {
+BEGIN_RCPP
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const std::string& >::type paramName(paramNameSEXP);
+    Rcpp::traits::input_parameter< const arma::Col<size_t>& >::type paramValue(paramValueSEXP);
+    CLI_SetParamUCol(paramName, paramValue);
+    return R_NilValue;
+END_RCPP
+}
+// CLI_SetParamMatWithInfo
+void CLI_SetParamMatWithInfo(const std::string& paramName, const LogicalVector& dimensions, const arma::mat& paramValue);
+RcppExport SEXP _RcppMLPACK_CLI_SetParamMatWithInfo(SEXP paramNameSEXP, SEXP dimensionsSEXP, SEXP paramValueSEXP) {
+BEGIN_RCPP
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const std::string& >::type paramName(paramNameSEXP);
+    Rcpp::traits::input_parameter< const LogicalVector& >::type dimensions(dimensionsSEXP);
+    Rcpp::traits::input_parameter< const arma::mat& >::type paramValue(paramValueSEXP);
+    CLI_SetParamMatWithInfo(paramName, dimensions, paramValue);
     return R_NilValue;
 END_RCPP
 }
@@ -190,14 +278,102 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// CLI_GetParamVectorStr
+const std::vector<std::string>& CLI_GetParamVectorStr(const std::string& paramName);
+RcppExport SEXP _RcppMLPACK_CLI_GetParamVectorStr(SEXP paramNameSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const std::string& >::type paramName(paramNameSEXP);
+    rcpp_result_gen = Rcpp::wrap(CLI_GetParamVectorStr(paramName));
+    return rcpp_result_gen;
+END_RCPP
+}
+// CLI_GetParamVectorInt
+const std::vector<int>& CLI_GetParamVectorInt(const std::string& paramName);
+RcppExport SEXP _RcppMLPACK_CLI_GetParamVectorInt(SEXP paramNameSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const std::string& >::type paramName(paramNameSEXP);
+    rcpp_result_gen = Rcpp::wrap(CLI_GetParamVectorInt(paramName));
+    return rcpp_result_gen;
+END_RCPP
+}
 // CLI_GetParamMat
-arma::mat& CLI_GetParamMat(const std::string& paramName);
+const arma::mat& CLI_GetParamMat(const std::string& paramName);
 RcppExport SEXP _RcppMLPACK_CLI_GetParamMat(SEXP paramNameSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const std::string& >::type paramName(paramNameSEXP);
     rcpp_result_gen = Rcpp::wrap(CLI_GetParamMat(paramName));
+    return rcpp_result_gen;
+END_RCPP
+}
+// CLI_GetParamUMat
+const arma::Mat<size_t>& CLI_GetParamUMat(const std::string& paramName);
+RcppExport SEXP _RcppMLPACK_CLI_GetParamUMat(SEXP paramNameSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const std::string& >::type paramName(paramNameSEXP);
+    rcpp_result_gen = Rcpp::wrap(CLI_GetParamUMat(paramName));
+    return rcpp_result_gen;
+END_RCPP
+}
+// CLI_GetParamRow
+const arma::vec CLI_GetParamRow(const std::string& paramName);
+RcppExport SEXP _RcppMLPACK_CLI_GetParamRow(SEXP paramNameSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const std::string& >::type paramName(paramNameSEXP);
+    rcpp_result_gen = Rcpp::wrap(CLI_GetParamRow(paramName));
+    return rcpp_result_gen;
+END_RCPP
+}
+// CLI_GetParamURow
+const arma::Col<size_t> CLI_GetParamURow(const std::string& paramName);
+RcppExport SEXP _RcppMLPACK_CLI_GetParamURow(SEXP paramNameSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const std::string& >::type paramName(paramNameSEXP);
+    rcpp_result_gen = Rcpp::wrap(CLI_GetParamURow(paramName));
+    return rcpp_result_gen;
+END_RCPP
+}
+// CLI_GetParamCol
+const arma::rowvec CLI_GetParamCol(const std::string& paramName);
+RcppExport SEXP _RcppMLPACK_CLI_GetParamCol(SEXP paramNameSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const std::string& >::type paramName(paramNameSEXP);
+    rcpp_result_gen = Rcpp::wrap(CLI_GetParamCol(paramName));
+    return rcpp_result_gen;
+END_RCPP
+}
+// CLI_GetParamUCol
+const arma::Row<size_t> CLI_GetParamUCol(const std::string& paramName);
+RcppExport SEXP _RcppMLPACK_CLI_GetParamUCol(SEXP paramNameSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const std::string& >::type paramName(paramNameSEXP);
+    rcpp_result_gen = Rcpp::wrap(CLI_GetParamUCol(paramName));
+    return rcpp_result_gen;
+END_RCPP
+}
+// CLI_GetParamMatWithInfo
+List CLI_GetParamMatWithInfo(const std::string& paramName);
+RcppExport SEXP _RcppMLPACK_CLI_GetParamMatWithInfo(SEXP paramNameSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const std::string& >::type paramName(paramNameSEXP);
+    rcpp_result_gen = Rcpp::wrap(CLI_GetParamMatWithInfo(paramName));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -325,12 +501,28 @@ static const R_CallMethodDef CallEntries[] = {
     {"_RcppMLPACK_CLI_SetParamDouble", (DL_FUNC) &_RcppMLPACK_CLI_SetParamDouble, 2},
     {"_RcppMLPACK_CLI_SetParamString", (DL_FUNC) &_RcppMLPACK_CLI_SetParamString, 2},
     {"_RcppMLPACK_CLI_SetParamBool", (DL_FUNC) &_RcppMLPACK_CLI_SetParamBool, 2},
-    {"_RcppMLPACK_CLI_SetParamMat", (DL_FUNC) &_RcppMLPACK_CLI_SetParamMat, 3},
+    {"_RcppMLPACK_CLI_SetParamVectorStr", (DL_FUNC) &_RcppMLPACK_CLI_SetParamVectorStr, 2},
+    {"_RcppMLPACK_CLI_SetParamVectorInt", (DL_FUNC) &_RcppMLPACK_CLI_SetParamVectorInt, 2},
+    {"_RcppMLPACK_CLI_SetParamMat", (DL_FUNC) &_RcppMLPACK_CLI_SetParamMat, 2},
+    {"_RcppMLPACK_CLI_SetParamUMat", (DL_FUNC) &_RcppMLPACK_CLI_SetParamUMat, 2},
+    {"_RcppMLPACK_CLI_SetParamRow", (DL_FUNC) &_RcppMLPACK_CLI_SetParamRow, 2},
+    {"_RcppMLPACK_CLI_SetParamURow", (DL_FUNC) &_RcppMLPACK_CLI_SetParamURow, 2},
+    {"_RcppMLPACK_CLI_SetParamCol", (DL_FUNC) &_RcppMLPACK_CLI_SetParamCol, 2},
+    {"_RcppMLPACK_CLI_SetParamUCol", (DL_FUNC) &_RcppMLPACK_CLI_SetParamUCol, 2},
+    {"_RcppMLPACK_CLI_SetParamMatWithInfo", (DL_FUNC) &_RcppMLPACK_CLI_SetParamMatWithInfo, 3},
     {"_RcppMLPACK_CLI_GetParamInt", (DL_FUNC) &_RcppMLPACK_CLI_GetParamInt, 1},
     {"_RcppMLPACK_CLI_GetParamDouble", (DL_FUNC) &_RcppMLPACK_CLI_GetParamDouble, 1},
     {"_RcppMLPACK_CLI_GetParamString", (DL_FUNC) &_RcppMLPACK_CLI_GetParamString, 1},
     {"_RcppMLPACK_CLI_GetParamBool", (DL_FUNC) &_RcppMLPACK_CLI_GetParamBool, 1},
+    {"_RcppMLPACK_CLI_GetParamVectorStr", (DL_FUNC) &_RcppMLPACK_CLI_GetParamVectorStr, 1},
+    {"_RcppMLPACK_CLI_GetParamVectorInt", (DL_FUNC) &_RcppMLPACK_CLI_GetParamVectorInt, 1},
     {"_RcppMLPACK_CLI_GetParamMat", (DL_FUNC) &_RcppMLPACK_CLI_GetParamMat, 1},
+    {"_RcppMLPACK_CLI_GetParamUMat", (DL_FUNC) &_RcppMLPACK_CLI_GetParamUMat, 1},
+    {"_RcppMLPACK_CLI_GetParamRow", (DL_FUNC) &_RcppMLPACK_CLI_GetParamRow, 1},
+    {"_RcppMLPACK_CLI_GetParamURow", (DL_FUNC) &_RcppMLPACK_CLI_GetParamURow, 1},
+    {"_RcppMLPACK_CLI_GetParamCol", (DL_FUNC) &_RcppMLPACK_CLI_GetParamCol, 1},
+    {"_RcppMLPACK_CLI_GetParamUCol", (DL_FUNC) &_RcppMLPACK_CLI_GetParamUCol, 1},
+    {"_RcppMLPACK_CLI_GetParamMatWithInfo", (DL_FUNC) &_RcppMLPACK_CLI_GetParamMatWithInfo, 1},
     {"_RcppMLPACK_CLI_EnableVerbose", (DL_FUNC) &_RcppMLPACK_CLI_EnableVerbose, 0},
     {"_RcppMLPACK_CLI_DisableVerbose", (DL_FUNC) &_RcppMLPACK_CLI_DisableVerbose, 0},
     {"_RcppMLPACK_CLI_ResetTimers", (DL_FUNC) &_RcppMLPACK_CLI_ResetTimers, 0},

--- a/src/mlpack/bindings/R/test_r_binding_main.cpp
+++ b/src/mlpack/bindings/R/test_r_binding_main.cpp
@@ -1,6 +1,6 @@
 /**
- * @file test_r_binding_main.cpp
- * @author Yashwant Singh
+ * @file bindings/R/test_r_binding_main.cpp
+ * @author Yashwant Singh Parihar
  *
  * A binding test for R.
  *
@@ -30,6 +30,14 @@ PARAM_DOUBLE_IN_REQ("double_in", "Input double, must be 4.0.", "d");
 PARAM_FLAG("flag1", "Input flag, must be specified.", "f");
 PARAM_FLAG("flag2", "Input flag, must not be specified.", "F");
 PARAM_MATRIX_IN("matrix_in", "Input matrix.", "m");
+PARAM_UMATRIX_IN("umatrix_in", "Input unsigned matrix.", "u");
+PARAM_COL_IN("col_in", "Input column.", "c");
+PARAM_UCOL_IN("ucol_in", "Input unsigned column.", "");
+PARAM_ROW_IN("row_in", "Input row.", "");
+PARAM_UROW_IN("urow_in", "Input unsigned row.", "");
+PARAM_MATRIX_AND_INFO_IN("matrix_and_info_in", "Input matrix and info.", "");
+PARAM_VECTOR_IN(int, "vector_in", "Input vector of numbers.", "");
+PARAM_VECTOR_IN(string, "str_vector_in", "Input vector of strings.", "");
 PARAM_MODEL_IN(GaussianKernel, "model_in", "Input model.", "");
 PARAM_FLAG("build_model", "If true, a model will be returned.", "");
 
@@ -37,6 +45,15 @@ PARAM_STRING_OUT("string_out", "Output string, will be 'hello2'.", "S");
 PARAM_INT_OUT("int_out", "Output int, will be 13.");
 PARAM_DOUBLE_OUT("double_out", "Output double, will be 5.0.");
 PARAM_MATRIX_OUT("matrix_out", "Output matrix.", "M");
+PARAM_UMATRIX_OUT("umatrix_out", "Output unsigned matrix.", "U");
+PARAM_COL_OUT("col_out", "Output column. 2x input column", "");
+PARAM_UCOL_OUT("ucol_out", "Output unsigned column. 2x input column.", "");
+PARAM_ROW_OUT("row_out", "Output row.  2x input row.", "");
+PARAM_UROW_OUT("urow_out", "Output unsigned row.  2x input row.", "");
+PARAM_MATRIX_OUT("matrix_and_info_out", "Output matrix and info; all numeric "
+    "elements multiplied by 3.", "");
+PARAM_VECTOR_OUT(int, "vector_out", "Output vector.", "");
+PARAM_VECTOR_OUT(string, "str_vector_out", "Output string vector.", "");
 PARAM_MODEL_OUT(GaussianKernel, "model_out", "Output model, with twice the "
     "bandwidth.", "");
 PARAM_DOUBLE_OUT("model_bw_out", "The bandwidth of the model.");
@@ -72,7 +89,90 @@ static void mlpackMain()
     arma::mat out = move(CLI::GetParam<arma::mat>("matrix_in"));
     out.shed_row(4);
     out.row(2) *= 2.0;
+
     CLI::GetParam<arma::mat>("matrix_out") = move(out);
+  }
+
+  // Input matrices should be at least 5 rows; the 5th row will be dropped and
+  // the 3rd row will be multiplied by two.
+  if (CLI::HasParam("umatrix_in"))
+  {
+    arma::Mat<size_t> out =
+        move(CLI::GetParam<arma::Mat<size_t>>("umatrix_in"));
+    out.shed_row(4);
+    out.row(2) *= 2;
+
+    CLI::GetParam<arma::Mat<size_t>>("umatrix_out") = move(out);
+  }
+
+  // An input column or row should have all elements multiplied by two.
+  if (CLI::HasParam("col_in"))
+  {
+    arma::vec out = move(CLI::GetParam<arma::vec>("col_in"));
+    out *= 2.0;
+
+    CLI::GetParam<arma::vec>("col_out") = move(out);
+  }
+
+  if (CLI::HasParam("ucol_in"))
+  {
+    arma::Col<size_t> out =
+        move(CLI::GetParam<arma::Col<size_t>>("ucol_in"));
+    out *= 2;
+
+    CLI::GetParam<arma::Col<size_t>>("ucol_out") = move(out);
+  }
+
+  if (CLI::HasParam("row_in"))
+  {
+    arma::rowvec out = move(CLI::GetParam<arma::rowvec>("row_in"));
+    out *= 2.0;
+
+    CLI::GetParam<arma::rowvec>("row_out") = move(out);
+  }
+
+  if (CLI::HasParam("urow_in"))
+  {
+    arma::Row<size_t> out =
+        move(CLI::GetParam<arma::Row<size_t>>("urow_in"));
+    out *= 2;
+
+    CLI::GetParam<arma::Row<size_t>>("urow_out") = move(out);
+  }
+
+  // Vector arguments should have the last element removed.
+  if (CLI::HasParam("vector_in"))
+  {
+    vector<int> out = move(CLI::GetParam<vector<int>>("vector_in"));
+    out.pop_back();
+
+    CLI::GetParam<vector<int>>("vector_out") = move(out);
+  }
+
+  if (CLI::HasParam("str_vector_in"))
+  {
+    vector<string> out = move(CLI::GetParam<vector<string>>("str_vector_in"));
+    out.pop_back();
+
+    CLI::GetParam<vector<string>>("str_vector_out") = move(out);
+  }
+
+  // All numeric elements should be multiplied by 3.
+  if (CLI::HasParam("matrix_and_info_in"))
+  {
+    typedef tuple<data::DatasetInfo, arma::mat> TupleType;
+    TupleType tuple = move(CLI::GetParam<TupleType>("matrix_and_info_in"));
+
+    const data::DatasetInfo& di = std::get<0>(tuple);
+    arma::mat& m = std::get<1>(tuple);
+
+    for (size_t i = 0; i < m.n_rows; ++i)
+    {
+      if (di.Type(i) == data::Datatype::numeric)
+        m.row(i) *= 2.0;
+    }
+
+    CLI::GetParam<arma::mat>("matrix_and_info_out") = move(m);
   }
 
   // If we got a request to build a model, then build it.

--- a/tests/testthat/test-R_binding.R
+++ b/tests/testthat/test-R_binding.R
@@ -1,91 +1,297 @@
-library(rlang)
-
-context("TestRunBindingCorrectly")
+# Test that when we run the binding correctly (with correct input parameters),
+# we get the expected output.
 test_that("TestRunBindingCorrectly", {
-  output <- test_r_binding(4.0, 12, "hello", flag1 = TRUE)
+  output <- test_r_binding(4.0, 12, "hello",
+                           flag1=TRUE)
+
   expect_true(output$double_out == 5.0)
   expect_true(output$int_out == 13)
   expect_true(output$string_out == "hello2")
 })
 
-context("TestRunBindingNoFlag")
+# If we forget the mandatory flag, we should get wrong results.
 test_that("TestRunBindingNoFlag", {
   output <- test_r_binding(4.0, 12, "hello")
+
   expect_true(output$double_out != 5.0)
   expect_true(output$int_out != 13)
   expect_true(output$string_out != "hello2")
 })
 
-context("TestRunBindingWrongString")
+# If we give the wrong string, we should get wrong results.
 test_that("TestRunBindingWrongString", {
-  output <- test_r_binding(4.0, 12, "goodbye", flag1 = TRUE)
+  output <- test_r_binding(4.0, 12, "goodbye",
+                          flag1=TRUE)
+
   expect_true(output$string_out != "hello2")
 })
 
-context("TestRunBindingWrongInt")
+# If we give the wrong int, we should get wrong results.
 test_that("TestRunBindingWrongInt", {
-  output <- test_r_binding(4.0, 15, "hello", flag1 = TRUE)
+  output <- test_r_binding(4.0, 15, "hello",
+                           flag1=TRUE)
+
   expect_true(output$int_out != 13)
 })
 
-context("TestRunBindingWrongDouble")
+# If we give the wrong double, we should get wrong results.
 test_that("TestRunBindingWrongDouble", {
-  output <- test_r_binding(2.0, 12, "hello", flag1 = TRUE)
+  output <- test_r_binding(2.0, 12, "hello",
+                           flag1=TRUE)
+
   expect_true(output$double_out != 5.0)
 })
 
-context("TestRunBadFlag")
+# If we give the second flag, this should fail.
 test_that("TestRunBadFlag", {
-  output <- test_r_binding(4.0, 12, "hello", flag1 = TRUE, flag2 = TRUE)
+  output <- test_r_binding(4.0, 12, "hello",
+                          flag1=TRUE,
+                          flag2=TRUE)
+
   expect_true(output$double_out != 5.0)
   expect_true(output$int_out != 13)
   expect_true(output$string_out != "hello2")
 })
 
-context("TestMatrix")
+# The matrix we pass in, we should get back with the third dimension doubled and
+# the fifth forgotten.
 test_that("TestMatrix", {
-  x <- matrix(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15), nrow = 5)
-  y <- duplicate(x, shallow = FALSE)
-  output <- test_r_binding(4.0, 12, "hello", y)
+  x <- matrix(rexp(500, rate = .1), ncol = 5)
 
-  expect_identical(dim(output$matrix_out), as.integer(c(4, 3)))
+  output <- test_r_binding(4.0, 12, "hello",
+                           matrix_in=x)
 
-  for (i in 1:3)
-    for (j in c(1,2,4))
+  expect_identical(dim(output$matrix_out), as.integer(c(100, 4)))
+  for (i in c(1, 2, 4)) {
+    for (j in 1:100) {
       expect_true(output$matrix_out[j, i] == x[j, i])
+    }
+  }
 
-  for(j in 1:3)
-    expect_true(output$matrix_out[3, j] == 2 * x[3, j])
+  for (j in 1:100) {
+    expect_true(output$matrix_out[j, 3] == 2 * x[j, 3])
+  }
 })
 
-context("TestMatrixForceCopy")
-test_that("TestMatrixForceCopy", {
-  x <- matrix(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15), nrow = 5)
-  output <- test_r_binding(4.0, 12, "hello", x, copy_all_inputs = TRUE)
+# The data.frame we pass in, we should get back with the third dimension doubled
+# and the fifth forgotten.
+test_that("TestDataFrame", {
+  y <- matrix(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15), nrow = 3)
+  x <- data.frame(y)
 
-  expect_identical(dim(output$matrix_out), as.integer(c(4, 3)))
+  output <- test_r_binding(4.0, 12, "hello",
+                           matrix_in=x)
 
-  for (i in 1:3)
-    for (j in c(1,2,4))
+  expect_identical(dim(output$matrix_out), as.integer(c(3, 4)))
+  for (i in c(1, 2, 4)) {
+    for (j in 1:3) {
       expect_true(output$matrix_out[j, i] == x[j, i])
+    }
+  }
 
-  for (j in 1:3)
-    expect_true(output$matrix_out[3, j] == 2 * x[3, j])
+  for (j in 1:3) {
+    expect_true(output$matrix_out[j, 3] == 2 * x[j, 3])
+  }
 })
 
-context("TestModel")
+# Same as TestMatrix but with an unsigned matrix.
+test_that("TestUMatrix", {
+  x <- matrix(as.integer(rexp(500, rate = .1)), ncol = 5)
+
+  output <- test_r_binding(4.0, 12, "hello",
+                           umatrix_in=x)
+
+  expect_identical(dim(output$umatrix_out), as.integer(c(100, 4)))
+  for (i in c(1, 2, 4)) {
+    for (j in 1:100) {
+      expect_true(output$umatrix_out[j, i] == x[j, i])
+    }
+  }
+
+  for (j in 1:100) {
+    expect_true(output$umatrix_out[j, 3] == 2 * x[j, 3])
+  }
+})
+
+# Test a column vector input parameter.
+test_that("TestCol", {
+  x <- matrix(rexp(100, rate = .1), nrow = 1)
+
+  output <- test_r_binding(4.0, 12, "hello",
+                           col_in=x)
+
+  expect_identical(dim(output$col_out), as.integer(c(1, 100)))
+  expect_identical(output$col_out, 2 * x)
+})
+
+# Test an unsigned column vector input parameter.
+test_that("TestUCol", {
+  x <- matrix(as.integer(rexp(100, rate = .1)), nrow = 1)
+
+  output <- test_r_binding(4.0, 12, "hello",
+                           ucol_in=x)
+
+  expect_identical(dim(output$ucol_out), as.integer(c(1, 100)))
+  expect_identical(output$ucol_out, 2 * x)
+})
+
+# Test a row vector input parameter.
+test_that("TestRow", {
+  x <- matrix(rexp(100, rate = .1), ncol = 1)
+
+  output <- test_r_binding(4.0, 12, "hello",
+                           row_in=x)
+
+  expect_identical(dim(output$row_out), as.integer(c(100, 1)))
+  expect_identical(output$row_out, 2 * x)
+})
+
+# Test an unsigned row vector input parameter.
+test_that("TestURow", {
+  x <- matrix(as.integer(rexp(100, rate = .1)), ncol = 1)
+
+  output <- test_r_binding(4.0, 12, "hello",
+                           urow_in=x)
+
+  expect_identical(dim(output$urow_out), as.integer(c(100, 1)))
+  expect_identical(output$urow_out, 2 * x)
+})
+
+# Test that we can pass a matrix with all numeric features.
+test_that("TestMatrixAndInfo", {
+  x <- matrix(rexp(500, rate = .1), ncol = 5)
+
+  output <- test_r_binding(4.0, 12, "hello",
+                           matrix_and_info_in=x)
+
+  expect_identical(dim(output$matrix_and_info_out), as.integer(c(100, 5)))
+  expect_identical(output$matrix_and_info_out, 2 * x)
+})
+
+# Test that we can pass a data.frame with all numeric features.
+test_that("TestDataFrameWithNoInfo", {
+  y <- matrix(rexp(500, rate = .1), ncol = 5)
+  x <- data.frame(y)
+
+  output <- test_r_binding(4.0, 12, "hello",
+                           matrix_and_info_in=x)
+
+  expect_identical(dim(output$matrix_and_info_out), as.integer(c(100, 5)))
+
+  for (i in 1:100) {
+    for (j in 1:5) {
+      expect_true(output$matrix_and_info_out[i, j] == 2 * x[i, j])
+    }
+  }
+})
+
+# Test that we can pass a data.frame with numeric and categorical features.
+test_that("TestDataFrameWithInfo", {
+  y <- matrix(rexp(90, rate = .1), ncol = 9)
+  x <- data.frame(y, "e" = letters[1:10])
+
+  output <- test_r_binding(4.0, 12, "hello",
+                           matrix_and_info_in=x)
+
+  expect_identical(dim(output$matrix_and_info_out), as.integer(c(10, 10)))
+
+  for (i in 1:9) {
+    for (j in 1:10) {
+      expect_true(output$matrix_and_info_out[j, i] == 2 * x[j, i])
+    }
+  }
+
+  for (j in 1:10) {
+    expect_true(output$matrix_and_info_out[j, 10] == j)
+  }
+})
+
+# Test that we can pass a data.frame with numeric and categorical features.
+test_that("TestDataFrameWithLogicalInfo", {
+  y <- matrix(rexp(90, rate = .1), ncol = 9)
+  x <- data.frame(y)
+  x["e"] <- c(T, F, F, T, T, F, F, F, F, T)
+
+  output <- test_r_binding(4.0, 12, "hello",
+                           matrix_and_info_in=x)
+
+  expect_identical(dim(output$matrix_and_info_out), as.integer(c(10, 10)))
+
+  for (i in 1:9) {
+    for (j in 1:10) {
+      expect_true(output$matrix_and_info_out[j, i] == 2 * x[j, i])
+    }
+  }
+  expect_identical(output$matrix_and_info_out[, 10], as.numeric(x[, "e"]))
+})
+
+# Test that we can pass a vector of ints and get back that same vector but with
+# the last element removed.
+test_that("TestIntVector", {
+  x <- c(1, 2, 3, 4, 5)
+
+  output <- test_r_binding(4.0, 12, "hello",
+                           vector_in=x)
+
+  expect_identical(output$vector_out, c(1:4))
+})
+
+# Test that we can pass a vector of strings and get back that same vector but
+# with the last element removed.
+test_that("TestStringVector", {
+  x <- letters[1:5]
+
+  output <- test_r_binding(4.0, 12, "hello",
+                           str_vector_in=x)
+
+  expect_identical(output$str_vector_out, letters[1:4])
+})
+
+# If we give data other than matrix/data.frame in matrix_in/matrix_and_info_in,
+# we should get an error. 
+test_that("TestNotMatrix", {
+  expect_error(test_r_binding(4.0, 12, "hello",
+                              matrix_in="wrong"))
+
+  expect_error(test_r_binding(4.0, 12, "hello",
+                              matrix_in=12))
+
+  expect_error(test_r_binding(4.0, 12, "hello",
+                              matrix_in=1e6))
+
+  expect_error(test_r_binding(4.0, 12, "hello",
+                              matrix_and_info_in="wrong"))
+
+  expect_error(test_r_binding(4.0, 12, "hello",
+                              matrix_and_info_in=12))
+
+  expect_error(test_r_binding(4.0, 12, "hello",
+                              matrix_and_info_in=1e6))
+})
+
+# First create a GaussianKernel object, then send it back and make sure we get
+# the right double value.
 test_that("TestModel", {
-  output1 <- test_r_binding(4.0, 12, "hello", build_model = TRUE)
-  output2 <- test_r_binding(4.0, 12, "hello", model_in = output1$model_out)
+  output1 <- test_r_binding(4.0, 12, "hello",
+                            build_model=TRUE)
+
+  output2 <- test_r_binding(4.0, 12, "hello",
+                            model_in=output1$model_out)
+
   expect_true(output2$model_bw_out == 20)
 })
 
-context("TestSerialization")
+# Test that we can serialize a model to disk and then use it again.
 test_that("TestSerialization", {
-  output1 <- test_r_binding(4.0, 12, "hello", build_model = TRUE)
+  output1 <- test_r_binding(4.0, 12, "hello",
+                            build_model=TRUE)
+
   serialize_gaussian_kernel("model.bin", output1$model_out)
+
   new_model <- unserialize_gaussian_kernel("model.bin")
   unlink("model.bin")
+
   output2 <- test_r_binding(4.0, 12, "hello", model_in = new_model)
+
   expect_true(output2$model_bw_out == 20)
 })


### PR DESCRIPTION
Hi @coatless @eddelbuettel @rcurtin: I have added all utility functions required by R bindings.
I also added `test_r_binding.R`(hand written binding which contain all the utilities). And I have also add some more test in `test-R_binding.R` which test all the utility functions.

Please guide whether these hand-written binding are correct or not? (Currently we have some more handwritten binding i.e `lars.R` and `pca.R`)
Same in the case of `r_util.cpp` .

If you all agree, Initially we can skip `serialize_to_xml` functionality, as this functionality is not provided by any of the mlpack bindings.

Thank You.